### PR TITLE
Supprime le lien "MyTodo" dans la navbar

### DIFF
--- a/views/components/header.ejs
+++ b/views/components/header.ejs
@@ -25,9 +25,6 @@
                             </li>
                         <% } %>
                         <li class="nav-item">
-                            <a class="nav-link" href="/">My Todos</a>
-                        </li>
-                        <li class="nav-item">
                             <a class="nav-link" href="/auth/logout">Logout</a>
                         </li>
                     <% } else { %>


### PR DESCRIPTION
Supprime le lien "MyTodo" dans la navbar qui est devenu inutile maintenant